### PR TITLE
Fix handoff restart to honor role_agents (gt-uoq)

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -496,6 +496,7 @@ func buildRestartCommand(sessionName string) (string, error) {
 		return "", fmt.Errorf("cannot parse session name %q: %w", sessionName, err)
 	}
 	gtRole := identity.GTRole()
+	simpleRole := config.ExtractSimpleRole(gtRole)
 
 	// Derive rigPath from session identity for --settings flag resolution
 	rigPath := ""
@@ -537,6 +538,10 @@ func buildRestartCommand(sessionName string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("resolving agent config: %w", err)
 		}
+	} else if simpleRole != "" {
+		// Preserve role_agents model selection across self-handoff by resolving
+		// runtime command via role-aware config (instead of default-agent lookup).
+		runtimeCmd = config.ResolveRoleAgentConfig(simpleRole, townRoot, rigPath).BuildCommandWithPrompt(beacon)
 	} else {
 		runtimeCmd = config.GetRuntimeCommandWithPrompt(rigPath, beacon)
 	}
@@ -545,7 +550,6 @@ func buildRestartCommand(sessionName string) (string, error) {
 	var exports []string
 	var agentEnv map[string]string // agent config Env (rc.toml [agents.X.env])
 	if gtRole != "" {
-		simpleRole := config.ExtractSimpleRole(gtRole)
 		// When GT_AGENT is set, resolve config with the override so we pick up
 		// the active agent's env (e.g., NODE_OPTIONS from [agents.X.env]).
 		// Otherwise, fall back to role-based resolution.
@@ -557,8 +561,10 @@ func buildRestartCommand(sessionName string) (string, error) {
 			} else {
 				runtimeConfig = config.ResolveRoleAgentConfig(simpleRole, townRoot, rigPath)
 			}
-		} else {
+		} else if simpleRole != "" {
 			runtimeConfig = config.ResolveRoleAgentConfig(simpleRole, townRoot, rigPath)
+		} else {
+			runtimeConfig = config.ResolveAgentConfig(townRoot, rigPath)
 		}
 		agentEnv = runtimeConfig.Env
 		exports = append(exports, "GT_ROLE="+gtRole)


### PR DESCRIPTION
## Summary
- add a regression test for self-handoff restart command generation when `role_agents` is configured
- update `buildRestartCommand` to build the runtime command from role-aware config when `GT_AGENT` override is not set
- keep explicit `GT_AGENT` override behavior unchanged

## Why
`buildRestartCommand` previously used `GetRuntimeCommandWithPrompt` in the no-override path, which resolves from default agent settings and can drop role-specific model flags. This caused self-handoff to lose `role_agents` selection.

## Tests
- `go test ./internal/cmd -run TestBuildRestartCommand_UsesRoleAgentsWhenNoAgentOverride -count=1`
- `go test ./...`

## Red/Green
- before fix: `TestBuildRestartCommand_UsesRoleAgentsWhenNoAgentOverride` fails (missing `--model sonnet`)
- after fix: same test passes
